### PR TITLE
Add default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It builds upon the [Python EnOcean](https://github.com/kipe/enocean) library.
 
 ### Setup as a daemon ###
 
-Assuming you want this tool to run as a daemon, which get automatically started by systemd: 
+Assuming you want this tool to run as a daemon, which get automatically started by systemd:
  - copy the `enoceanmqtt.service` to `/etc/systemd/system/` (making only a symbolic link [will not work](https://bugzilla.redhat.com/show_bug.cgi?id=955379))
  - `systemctl enable enoceanmqtt`
  - `systemctl start enoceanmqtt`
@@ -42,6 +42,14 @@ After reboot, this assigns the symbolic name `/dev/enocean`. If you use a differ
 ## Configuration ##
 
 Please take a look at the provided [enoceanmqtt.conf](enoceanmqtt.conf) sample config file. Most should be self explaining.
+
+Multiple config files can be specified as command line arguments. Values are merged, later config files override values of the former. This is the order:
+
+* `/etc/enoceanmqtt.conf`
+* in Dockerfile: `/enoceanmqtt-default.conf`, compare [enoceanmqtt-default.conf](enoceanmqtt-default.conf).
+* any further command line argument.
+
+This can be used to split security sensitive values from the device configs.
 
 ### Answering EnOcean Messages ###
 

--- a/enoceanmqtt-default.conf
+++ b/enoceanmqtt-default.conf
@@ -1,0 +1,6 @@
+[CONFIG]
+enocean_port    = /dev/enocean
+log_packets     = 1
+mqtt_host       = localhost
+mqtt_port       = 1883
+mqtt_prefix     = enocean/


### PR DESCRIPTION
Order is: /etc/enoceanmqtt.conf, /enoceanmqtt-default.conf, command line args.